### PR TITLE
Added custom logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.gem
 .bundle/
 Gemfile.lock
+
+test/support/delivery_log.log

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'rake'
   gem 'minitest'
 end

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ These are the default options. Salt to taste.
 
       # Write all deliveries to $stdout
       config.log = false
+
+      # Write logs to any custom logger you want
+      # For using Logger you may want to: require 'logger'
+      config.logger = Logger.new('log/mailers.log')
     end
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -11,72 +11,80 @@ A lightweight (~100 line) alternative to ActionMailer for hipsters who use Ruby 
 
 IdleMailer is all about providing mailer classes and templates. But [the mail gem](http://www.rubydoc.info/gems/mail) has a great API, so you have unfettered access to it in your mailers through the "mail" object.
 
-    # Define your mailer class
-    class WidgetMailer
-      include IdleMailer::Mailer
+```ruby
+# Define your mailer class
+class WidgetMailer
+  include IdleMailer::Mailer
 
-      def initialize(user, widget)
-        mail.to = user.email
-        mail.subject = "Widget #{widget.sku}"
-        @widget = widget
-      end
-    end
+  def initialize(user, widget)
+    mail.to = user.email
+    mail.subject = "Widget #{widget.sku}"
+    @widget = widget
+  end
+end
 
-    # Create widget.html.erb and/or widget.text.erb templates.
-    # They'll have access to instance variables like @widget above.
+# Create widget.html.erb and/or widget.text.erb templates.
+# They'll have access to instance variables like @widget above.
 
-    # Send your mail
-    mailer = WidgetMailer.new(current_user, widget)
-    mailer.deliver
+# Send your mail
+mailer = WidgetMailer.new(current_user, widget)
+mailer.deliver
+```
 
 ## Configure
 
 These are the default options. Salt to taste.
 
-    IdleMailer.config do |config|
-      # Directory containing the mailer templates
-      config.templates = Pathname.new(Dir.getwd).join('templates')
+```ruby
+IdleMailer.config do |config|
+  # Directory containing the mailer templates
+  config.templates = Pathname.new(Dir.getwd).join('templates')
 
-      # Name of the layout template. Here, the file(s) would be named
-      # mailer_layout.html.erb and/or mailer_layout.text.erb.
-      config.layout = 'mailer_layout'
+  # Name of the layout template. Here, the file(s) would be named
+  # mailer_layout.html.erb and/or mailer_layout.text.erb.
+  config.layout = 'mailer_layout'
 
-      # Email delivery method (mail gem). Set to :test when testing or when developing locally
-      config.delivery_method = :smtp
+  # Email delivery method (mail gem). Set to :test when testing or when developing locally
+  config.delivery_method = :smtp
 
-      # Delivery options (mail gem)
-      config.delivery_options = {
-        user_name: ENV['MAIL_USER'],
-        password: ENV['MAIL_PASSWORD'],
-        domain: ENV['MAIL_DOMAIN'],
-        address: ENV['MAIL_ADDRESS'],
-        port: ENV['MAIL_PORT'] || 587,
-        authentication: ENV['MAIL_AUTHENTICATION'] || 'plain',
-        enable_starttls_auto: (ENV['MAIL_TLS'] ? true : false)
-      }
+  # Delivery options (mail gem)
+  config.delivery_options = {
+    user_name: ENV['MAIL_USER'],
+    password: ENV['MAIL_PASSWORD'],
+    domain: ENV['MAIL_DOMAIN'],
+    address: ENV['MAIL_ADDRESS'],
+    port: ENV['MAIL_PORT'] || 587,
+    authentication: ENV['MAIL_AUTHENTICATION'] || 'plain',
+    enable_starttls_auto: (ENV['MAIL_TLS'] ? true : false)
+  }
 
-      # Default "from" address for all mailers
-      config.default_from = nil
+  # Default "from" address for all mailers
+  config.default_from = nil
 
-      # Write all deliveries to $stdout
-      config.log = false
+  # Write all deliveries to $stdout
+  config.log = false
 
-      # Write logs to any custom logger you want
-      # For using Logger you may want to: require 'logger'
-      config.logger = Logger.new('log/mailers.log')
-    end
+  # Write logs to any custom logger you want
+  # For using Logger you may want to: require 'logger'
+  config.logger = Logger.new('log/mailers.log')
+end
+```
 
 ## Testing
 
 Put the mailer in testing mode:
 
-    IdleMailer.config do |config|
-      config.delivery_method = :test
-    end
+```ruby
+IdleMailer.config do |config|
+  config.delivery_method = :test
+end
+```
 
 Then use mail gem's built in testing helpers in your specs:
 
-    sent = Mail::TestMailer.deliveries.any? { |mail| mail.to.include? @user.email }
+```ruby
+sent = Mail::TestMailer.deliveries.any? { |mail| mail.to.include? @user.email }
+```
 
 ## License
 

--- a/lib/idlemailer/config.rb
+++ b/lib/idlemailer/config.rb
@@ -6,7 +6,7 @@ module IdleMailer
   #   delivery_options Hash of delivery options (see the mail gem for all options)
   #   default_from Default "from" address if it's left blank
   #   log When true, writes delivered messages to $stdout (default false)
-  Config = Struct.new(:templates, :layout, :delivery_method, :delivery_options, :default_from, :log)
+  Config = Struct.new(:templates, :layout, :delivery_method, :delivery_options, :default_from, :log, :logger)
   @config = Config.new
 
   # Takes a block and hands it an IdleMailer::Config object

--- a/lib/idlemailer/mailer.rb
+++ b/lib/idlemailer/mailer.rb
@@ -18,15 +18,19 @@ module IdleMailer
   #  mailer.deliver
   #
   module Mailer
+
     # Deliver mail
     def deliver
-      mailer = IdleMailer::Message.new(mail, self)
       mailer.deliver!
     end
 
     # Render an ERB template with the mailer's binding
     def render(template)
       template.result(binding { yield })
+    end
+
+    def mailer
+      @mailer ||= IdleMailer::Message.new(mail, self)
     end
 
     private

--- a/lib/idlemailer/version.rb
+++ b/lib/idlemailer/version.rb
@@ -1,5 +1,5 @@
 # IdleMailer module
 module IdleMailer
   # Version number
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/test/delivery_test.rb
+++ b/test/delivery_test.rb
@@ -38,4 +38,40 @@ class DeliveryTest < Minitest::Test
     WidgetMailer.new('user@example.com', @widget).deliver
     assert_match /test html layout/i, Mail::TestMailer.deliveries.first.to_s
   end
+
+  def test_namespaced_mailer_template_name
+    user = User.new('Rafael Fidelis', 'myemail@email.com')
+    mail = MyNamespace::V1::Mailers::UsersMailer.new(user)
+
+    assert_equal mail.mailer.send(:template_name), 'my_namespace/v1/mailers/users'
+  end
+
+  def test_namespaced_html_template
+    user = User.new('Rafael Fidelis', 'myemail@email.com')
+    mail = MyNamespace::V1::Mailers::UsersMailer.new(user).deliver
+
+    assert_match /Welcome #{user.name} to IdleMailer/i, mail.to_s
+  end
+
+  def test_ensure_deliver_method_call
+    message = IdleMailer::Message.new('test@mailer.com', nil)
+
+    assert_raises RuntimeError do
+      message.send(:deliver_message!)
+    end
+  end
+
+  def test_log_to_file
+    require 'logger'
+    log_file = File.expand_path('support/delivery_log.log', File.dirname(__FILE__))
+
+    IdleMailer.config do |config|
+      config.logger = Logger.new(log_file)
+    end
+
+    WidgetMailer.new('user@example.com', @widget).deliver
+
+    assert_equal true, File.exists?(log_file)
+  end
+
 end

--- a/test/support/namespaced_mailer.rb
+++ b/test/support/namespaced_mailer.rb
@@ -1,0 +1,16 @@
+module MyNamespace
+  module V1
+    module Mailers
+      class UsersMailer
+        include IdleMailer::Mailer
+
+        def initialize(user)
+          @user = user
+
+          mail.to = user.email
+          mail.subject = "#{user.name} Welcome"
+        end
+      end
+    end
+  end
+end

--- a/test/support/templates/my_namespace/v1/mailers/users.html.erb
+++ b/test/support/templates/my_namespace/v1/mailers/users.html.erb
@@ -1,0 +1,1 @@
+Welcome <%= @user.name %> to IdleMailer

--- a/test/support/user.rb
+++ b/test/support/user.rb
@@ -1,0 +1,2 @@
+require 'ostruct'
+User = Struct.new(:name, :email)


### PR DESCRIPTION
This PR allow users to log to custom logger besides only `$stdout`,  and correct `template_name` to respect namespaced mailer classes, so if you have `App::V1::Mailers::UsersMailer` IdleMailer will search for `app/v1/mailers/users_mailer.html.#{type}` template file.

I've monkey patched my code, if you release a new version of IdleMailer, let me know!

Thanks 👍  